### PR TITLE
Upgrade webpack to 5.38.1

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -24,7 +24,7 @@
     "file-loader": "^6.2.0",
     "postcss-loader": "^4.0.4",
     "postcss-preset-env": "^6.7.0",
-    "webpack": "^5.3.0",
+    "webpack": "^5.38.1",
     "webpack-cli": "^4.1.0",
     "webpack-dev": "^1.1.1"
   }


### PR DESCRIPTION
In my codebase, if I added a syntax error to a source file I would get the following error and apex-nitro would immediately exit (I would have to fix the compilation error and re-launch):

```
webpack-cli] HookWebpackError: webpack.WebpackError is not a constructor
    at makeWebpackError (/home/trent/Projects/my-awesome-nitro-project/node_modules/webpack/lib/HookWebpackError.js:53:9)
    at /home/trent/Projects/my-awesome-nitro-project/node_modules/webpack/lib/Compilation.js:2002:11
    at Hook.eval [as callAsync] (eval at create (/home/trent/Projects/my-awesome-nitro-project/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:12:1)
    at Hook.CALL_ASYNC_DELEGATE [as _callAsync] (/home/trent/Projects/my-awesome-nitro-project/node_modules/tapable/lib/Hook.js:18:14)
    at cont (/home/trent/Projects/my-awesome-nitro-project/node_modules/webpack/lib/Compilation.js:1996:40)
    at /home/trent/Projects/my-awesome-nitro-project/node_modules/webpack/lib/Compilation.js:2045:9
    at /home/trent/Projects/my-awesome-nitro-project/node_modules/neo-async/async.js:2830:7
    at Object.each (/home/trent/Projects/my-awesome-nitro-project/node_modules/neo-async/async.js:2850:39)
    at Compilation.createChunkAssets (/home/trent/Projects/my-awesome-nitro-project/node_modules/webpack/lib/Compilation.js:3110:12)
    at /home/trent/Projects/my-awesome-nitro-project/node_modules/webpack/lib/Compilation.js:2040:13
-- inner error --
```

I ruled apex-nitro out by running, and thus producing the same error:

```
npx webpack --config webpack.dev.json
```

So I checked npmjs to see what is the latest version: https://www.npmjs.com/package/webpack,

After I modified package.json with the version in this PR and ran `npm i` and re run either nitro or webpack, the error is gone.